### PR TITLE
Fix location that scripts are downloaded from

### DIFF
--- a/_updatePublisher.bat
+++ b/_updatePublisher.bat
@@ -7,7 +7,7 @@ SET publisher_jar=publisher.jar
 SET input_cache_path=%CD%\input-cache\
 SET skipPrompts=false
 
-SET scriptdlroot=https://raw.githubusercontent.com/FHIR/ig-publisher-scripts/main
+SET scriptdlroot=https://raw.githubusercontent.com/HL7/ig-publisher-scripts/main
 SET update_bat_url=%scriptdlroot%/_updatePublisher.bat
 SET gen_bat_url=%scriptdlroot%/_genonce.bat
 SET gencont_bat_url=%scriptdlroot%/_gencontinuous.bat

--- a/_updatePublisher.sh
+++ b/_updatePublisher.sh
@@ -5,7 +5,7 @@ dlurl=$pubsource$publisher_jar
 
 input_cache_path=$PWD/input-cache/
 
-scriptdlroot=https://raw.githubusercontent.com/FHIR/ig-publisher-scripts/main
+scriptdlroot=https://raw.githubusercontent.com/HL7/ig-publisher-scripts/main
 update_bat_url=$scriptdlroot/_updatePublisher.bat
 gen_bat_url=$scriptdlroot/_genonce.bat
 gencont_bat_url=$scriptdlroot/_gencontinuous.bat


### PR DESCRIPTION
The download location erroneously pointed to the `FHIR` GitHub organization rather than the `HL7` organization.  As a result, if you chose to update the scripts dynamically, they would all be replaced with files having the content: `404: Not Found`.

I've tested the `.sh` script on Mac and confirmed that it worked but was not able to test the Windows script (although it _should_ work).