### PR TITLE
Use curl instead of ping to test connection

### DIFF
--- a/_updatePublisher.sh
+++ b/_updatePublisher.sh
@@ -31,11 +31,7 @@ while [ "$#" -gt 0 ]; do
 done
 
 echo "Checking internet connection"
-case "$OSTYPE" in
-	linux-gnu* ) ping tx.fhir.org -4 -c 1 -w 1000 >/dev/null ;;
-  darwin* )	ping tx.fhir.org -c 1 >/dev/null ;;
-	*) echo "unknown: $OSTYPE"; exit 1 ;;
-esac
+curl -sSf tx.fhir.org > /dev/null
 
 if [ $? -ne 0 ] ; then
   echo "Offline (or the terminology server is down), unable to update.  Exiting"


### PR DESCRIPTION
This is consistent with `_genonce.sh` 

Ping (ICMP) can be blocked, especially behind a VPN. This change correlates with the PR at fhir-shorthand (https://github.com/HL7/fhir-shorthand/pull/105).