### PR TITLE
Switch host for internet connection check to captive.apple.com

### DIFF
--- a/_genonce.bat
+++ b/_genonce.bat
@@ -3,7 +3,7 @@ SET publisher_jar=publisher.jar
 SET input_cache_path=%CD%\input-cache
 
 ECHO Checking internet connection...
-PING tx.fhir.org -4 -n 1 -w 1000 | FINDSTR TTL && GOTO isonline
+PING captive.apple.com -4 -n 1 -w 1000 | FINDSTR TTL && GOTO isonline
 ECHO We're offline...
 SET txoption=-tx n/a
 GOTO igpublish

--- a/_genonce.sh
+++ b/_genonce.sh
@@ -2,7 +2,7 @@
 publisher_jar=publisher.jar
 input_cache_path=./input-cache/
 echo Checking internet connection...
-curl -sSf tx.fhir.org > /dev/null
+curl -sSf captive.apple.com > /dev/null
 
 if [ $? -eq 0 ]; then
 	echo "Online"

--- a/_updatePublisher.bat
+++ b/_updatePublisher.bat
@@ -20,7 +20,7 @@ IF "%~1"=="/f" SET skipPrompts=y
 
 ECHO.
 ECHO Checking internet connection...
-PING tx.fhir.org -4 -n 1 -w 1000 | FINDSTR TTL && GOTO isonline
+PING captive.apple.com -4 -n 1 -w 1000 | FINDSTR TTL && GOTO isonline
 ECHO We're offline, nothing to do...
 GOTO end
 

--- a/_updatePublisher.sh
+++ b/_updatePublisher.sh
@@ -31,7 +31,7 @@ while [ "$#" -gt 0 ]; do
 done
 
 echo "Checking internet connection"
-curl -sSf tx.fhir.org > /dev/null
+curl -sSf captive.apple.com > /dev/null
 
 if [ $? -ne 0 ] ; then
   echo "Offline (or the terminology server is down), unable to update.  Exiting"


### PR DESCRIPTION
This allows for these scripts to still work when tx.fhir.org is entirely down
so an alternate tx server can be used.