### PR TITLE
Add optional JAVA_OPTS env.

### DIFF
--- a/_genonce.sh
+++ b/_genonce.sh
@@ -16,12 +16,12 @@ echo "$txoption"
 
 publisher=$input_cache_path/$publisher_jar
 if test -f "$publisher"; then
-	java -jar $publisher -ig . $txoption $*
+	java $JAVA_OPTS -jar $publisher -ig . $txoption $*
 
 else
 	publisher=../$publisher_jar
 	if test -f "$publisher"; then
-		java -jar $publisher -ig . $txoption $*
+		java $JAVA_OPTS -jar $publisher -ig . $txoption $*
 	else
 		echo IG Publisher NOT FOUND in input-cache or parent folder.  Please run _updatePublisher.  Aborting...
 	fi


### PR DESCRIPTION
When running IG Publisher, we need to set the max heap size -Xmx. This is especially important for CI/CD or running the publisher in docker. This patch introduces an env variable to allow this.