### PR TITLE
Allow running ./_gencontinuous.sh from parent dir

### DIFF
--- a/_gencontinuous.sh
+++ b/_gencontinuous.sh
@@ -1,2 +1,2 @@
 #!/bin/bash
-./_genonce.sh -watch
+"$(dirname "$0")/_genonce.sh" -watch


### PR DESCRIPTION
I like to clone https://github.com/HL7/ig-publisher-scripts into a subdirectory like

```
git subtree add --prefix .ig-publisher-scripts https://github.com/HL7/ig-publisher-scripts  main --squash
```

So I can keep my IG root directory "clean" (i.e., without piles of shell scripts) then do
```
.ig-publisher-scripts/_genonce.sh
```

(which works fine)

or 

```
.ig-publisher-scripts/_gencontinuous.sh
```

(which breaks; this PR fixes that).