### PR TITLE
Re-enable JAVA_TOOL_OPTIONS to be set as an environment variable

### DIFF
--- a/_genonce.sh
+++ b/_genonce.sh
@@ -14,7 +14,7 @@ fi
 
 echo "$txoption"
 
-export JAVA_TOOL_OPTIONS=-Dfile.encoding=UTF-8
+export JAVA_TOOL_OPTIONS="$JAVA_TOOL_OPTIONS -Dfile.encoding=UTF-8"
 
 publisher=$input_cache_path/$publisher_jar
 if test -f "$publisher"; then


### PR DESCRIPTION
This change re-enables `JAVA_TOOL_OPTIONS` to be as an environment variable as it was possible until https://github.com/HL7/ig-publisher-scripts/pull/17.

IG generation is broken otherwise on certain setups (Chromebooks or [Docker](https://github.com/HL7/ig-publisher-scripts/pull/15)) without the increased heap size.