### PR TITLE
Set Execute Flag On Updated Scripts

### DIFF
--- a/_updatePublisher.sh
+++ b/_updatePublisher.sh
@@ -117,13 +117,16 @@ if [[ $skipPrompts == true ]] || [[ $response =~ ^[yY].*$ ]]; then
 
   curl -L $gencont_sh_url -o /tmp/_gencontinuous.new
   cp /tmp/_gencontinuous.new _gencontinuous.sh
+  chmod +x _gencontinuous.sh
   rm /tmp/_gencontinuous.new
 
   curl -L $gen_sh_url -o /tmp/_genonce.new
   cp /tmp/_genonce.new _genonce.sh
+  chmod +x _genonce.sh
   rm  /tmp/_genonce.new
 
   curl -L $update_sh_url -o /tmp/_updatePublisher.new
   cp /tmp/_updatePublisher.new _updatePublisher.sh
+  chmod +x _updatePublisher.sh
   rm /tmp/_updatePublisher.new
 fi


### PR DESCRIPTION
Sets the execute flag on all the updated shell scripts when they are downloaded in `_updatePublisher.sh`.

The downloaded shell scripts in `_updatePublisher.sh` are not marked as executable automatically.  This makes it look like the shell scripts loose their "executability" after update.  This PR re-sets the execute flag for the shell scripts so they continue to be able to be executed.