### PR TITLE
fix overwrite of JAVA_TOOL_OPTIONS, fixes #41

### DIFF
--- a/_build.sh
+++ b/_build.sh
@@ -101,7 +101,6 @@ function run_publisher() {
     if [[ "$JAVA_TOOL_OPTIONS" != *"-Dfile.encoding=UTF-8"* ]]; then
       export JAVA_TOOL_OPTIONS+=" -Dfile.encoding=UTF-8"
     fi
-    #export JAVA_TOOL_OPTIONS="$JAVA_TOOL_OPTIONS -Dfile.encoding=UTF-8"
     java $JAVA_OPTS -jar "$jar_location" -ig . "${extra_flags[@]}"
   else
     echo "IG Publisher NOT FOUND in input-cache or parent folder. Please run update. Aborting..."

--- a/_build.sh
+++ b/_build.sh
@@ -98,7 +98,10 @@ function run_publisher() {
   local extra_flags=("$@")
   if [ "$jar_location" != "not_found" ]; then
     echo "jar_location is: $jar_location"
-    export JAVA_TOOL_OPTIONS="-Dfile.encoding=UTF-8"
+    if [[ "$JAVA_TOOL_OPTIONS" != *"-Dfile.encoding=UTF-8"* ]]; then
+      export JAVA_TOOL_OPTIONS+=" -Dfile.encoding=UTF-8"
+    fi
+    #export JAVA_TOOL_OPTIONS="$JAVA_TOOL_OPTIONS -Dfile.encoding=UTF-8"
     java $JAVA_OPTS -jar "$jar_location" -ig . "${extra_flags[@]}"
   else
     echo "IG Publisher NOT FOUND in input-cache or parent folder. Please run update. Aborting..."


### PR DESCRIPTION
The bash script overwrites JAVA_TOOL_OPTIONS instead of adding "-Dfile.encoding=UTF-8". Any settings in the environment variable is lost. The proposed code adds UTF-8 encoding setting after any existing settings if it is not present.